### PR TITLE
Fix AI answer box sizing at responsive widths

### DIFF
--- a/ai_answers.py
+++ b/ai_answers.py
@@ -1591,7 +1591,7 @@ class SXNGPlugin(Plugin):
                             }}
                         }}
                         #sxng-answer-wrap {{ position: relative; }}
-                        #sxng-answer-wrap.sxng-collapsed {{ height: 14rem; overflow: hidden; }}
+                        #sxng-answer-wrap.sxng-collapsed {{ max-height: 14rem; overflow: hidden; }}
                         .sxng-show-more-wrap {{
                             display: none; position: absolute; bottom: 0; left: 0; right: 0; height: 4rem;
                             background: linear-gradient(to bottom, transparent, var(--color-base-background, #fff));

--- a/ai_answers.py
+++ b/ai_answers.py
@@ -473,6 +473,8 @@ FRONTEND_JS_TEMPLATE = r"""
     const box = document.getElementById('sxng-stream-box');
     const data = document.getElementById('sxng-stream-data');
     const answerWrap = document.getElementById('sxng-answer-wrap');
+    const answersContainer = box.closest('#answers');
+    if (answersContainer) answersContainer.classList.add('sxng-ai-answers-container');
     const wrapper = box.closest('.answer');
     if (wrapper) wrapper.style.display = 'none';
     let restored = false;
@@ -1577,6 +1579,11 @@ class SXNGPlugin(Plugin):
                         }}
                         .sxng-chunk {{
                             opacity: 1;
+                        }}
+                        @media screen and (min-width: 50em) and (max-width: 79.75em) {{
+                            .center-alignment-yes #main_results #answers.sxng-ai-answers-container {{
+                                margin-inline-start: 3rem;
+                            }}
                         }}
                         @media (min-width: 769px) {{
                             .sxng-chunk {{


### PR DESCRIPTION
Hi! This fixes two responsive layout issues with the AI answer box.

## What changed

- Keeps the answer box aligned with regular results at tablet-sized window widths
- Lets short answers shrink to fit their content
- Keeps the existing 14rem limit and Show more behavior for longer answers
- Uses logical spacing so right-to-left layouts are handled correctly

## Testing

- Tested the alignment at desktop, tablet, and mobile widths in SearXNG
- Tested short answers and confirmed the box shrinks correctly
- Python syntax check passed
- Generated JavaScript syntax check passed
- Git diff validation passed

## AI disclosure

This code and pull request text were created with help from OpenAI Codex. The changes were manually tested and reviewed before submission.